### PR TITLE
メール一斉送信機能 #44

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use App\Services\Emails\SendEmailService;
 
 class Kernel extends ConsoleKernel
 {
@@ -24,8 +25,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
+        // メール一斉送信
+        $schedule->call(function () {
+            SendEmailService::runJob();
+        })->cron('* * * * *');
     }
 
     /**

--- a/app/Eloquents/Email.php
+++ b/app/Eloquents/Email.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Eloquents;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Email extends Model
+{
+    //
+}

--- a/app/Eloquents/Email.php
+++ b/app/Eloquents/Email.php
@@ -4,7 +4,18 @@ namespace App\Eloquents;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property bool $is_sent
+ */
 class Email extends Model
 {
-    //
+    /**
+     * メール送信済であれば true を返す動的プロパティを作る
+     *
+     * @return bool
+     */
+    public function getIsSentAttribute(): bool
+    {
+        return !empty($this->sent_at);
+    }
 }

--- a/app/Eloquents/Email.php
+++ b/app/Eloquents/Email.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property bool $is_sent
+ * @property bool $is_locked
  */
 class Email extends Model
 {
@@ -17,5 +18,15 @@ class Email extends Model
     public function getIsSentAttribute(): bool
     {
         return !empty($this->sent_at);
+    }
+
+    /**
+     * 排他ロック中であれば true を返す動的プロパティを作る
+     *
+     * @return bool
+     */
+    public function getIsLockedAttribute(): bool
+    {
+        return !empty($this->locked_at);
     }
 }

--- a/app/Eloquents/Page.php
+++ b/app/Eloquents/Page.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Eloquents;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Page extends Model
+{
+    //
+}

--- a/app/Eloquents/User.php
+++ b/app/Eloquents/User.php
@@ -73,6 +73,17 @@ class User extends Authenticatable
     }
 
     /**
+     * メール認証が完了しているユーザーだけに限定するクエリスコープ
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeVerified($query)
+    {
+        return $query->whereNotNull('email_verified_at')->whereNotNull('univemail_verified_at');
+    }
+
+    /**
      * ログイン ID から該当ユーザーを取得する
      *
      * @param string $login_id

--- a/app/Http/Controllers/Staff/SendEmails/DestroyAction.php
+++ b/app/Http/Controllers/Staff/SendEmails/DestroyAction.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Staff\SendEmails;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Eloquents\Email;
+
+class DestroyAction extends Controller
+{
+    public function __invoke()
+    {
+        Email::query()->delete();
+
+        return redirect()
+            ->route('staff.send_emails')
+            ->with('toast', '一斉メール送信をキャンセルしました');
+    }
+}

--- a/app/Http/Controllers/Staff/SendEmails/ListAction.php
+++ b/app/Http/Controllers/Staff/SendEmails/ListAction.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Staff\SendEmails;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Eloquents\Page;
+
+class ListAction extends Controller
+{
+    public function __invoke()
+    {
+        return view('staff.send_emails.list')
+            ->with('pages', Page::all());
+    }
+}

--- a/app/Http/Controllers/Staff/SendEmails/StoreAction.php
+++ b/app/Http/Controllers/Staff/SendEmails/StoreAction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Staff\SendEmails;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Services\Emails\SendEmailService;
+use App\Eloquents\Page;
+use App\Eloquents\User;
+
+class StoreAction extends Controller
+{
+    /**
+     * @var SendEmailService
+     */
+    public $sendEmailService;
+
+    public function __construct(SendEmailService $sendEmailService)
+    {
+        $this->sendEmailService = $sendEmailService;
+    }
+
+    public function __invoke(Request $request)
+    {
+        $page = Page::findOrFail((int)$request->page_id);
+        $users = User::verified()->get();
+        $this->sendEmailService->bulkEnqueue(
+            $page->title,
+            $page->body,
+            $users
+        );
+
+        return redirect()
+            ->route('staff.send_emails')
+            ->with('toast', '一斉メール送信の予約が完了しました');
+    }
+}

--- a/app/Mail/Emails/SendEmailServiceMailable.php
+++ b/app/Mail/Emails/SendEmailServiceMailable.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail\Emails;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendEmailServiceMailable extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public $subject;
+    public $body;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param  string  $subject  タイトル
+     * @param  string  $body  本文
+     * @return void
+     */
+    public function __construct(string $subject, string $body)
+    {
+        $this->subject = $subject;
+        $this->body = $body;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->markdown('emails.emails.send_email_service')
+            ->subject($this->subject);
+    }
+}

--- a/app/Services/Emails/SendEmailService.php
+++ b/app/Services/Emails/SendEmailService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Emails;
+
+use App\Eloquents\Email;
+
+class SendEmailService
+{
+    private const NUMBERS_PER_EXECUTE = 60; // 1回の処理で取得するメールレコード数
+    private const SEND_INTERVAL_SEC = 1; // メール送信間隔(秒)
+    private const SEC_PER_JOB = 60; // プログラム強制終了まで
+    private const NUM_RETRY_PER_EMAIL_ADDRESS = 3; // 送信失敗した場合，リトライする回数
+    private const NUM_RETRY_PER_JOB = 10; // １回のジョブで繰り返す回数
+
+    public function enqueue()
+    {
+        for ($i = 0; $i < 10; ++$i) {
+            $email = new Email();
+            $email->subject = "件名";
+            // ...
+            $email->save();
+        }
+    }
+
+    public function runJob()
+    {
+        $start_time = now(); // 開始時刻(UNIXエポック) (秒)
+
+        // 今期失敗回数
+        // (この関数が呼び出されて以降失敗した回数)
+        $count_failed_now = 0;
+
+        $emails = Email::orderBy('id', 'ASC')
+                            ->where('is_locked', false) // 排他ロックされていない
+                            ->where('is_sent', false)   // かつ，未送信
+                            ->where('count_failed', '<', self::NUM_RETRY_PER_EMAIL_ADDRESS) // かつ，リトライ上限に達していないレコード
+                            ->take(self::NUMBERS_PER_EXECUTE)
+                            ->get();           // 最新 self::NUMBERS_PER_EXECUTE 件を取得
+        foreach ($emails as $email) {
+            // ロック処理
+            $email->is_locked = true;
+            $email->save();
+
+            try {
+                // ...何らかの送信処理...
+
+                // 送信済みフラグセット
+                $email->is_sent = true;
+                $email->save();
+            } catch (Exception $e) {
+                // 送信失敗したので失敗カウントを1つ追加
+                ++$email->count_failed;
+                ++$count_failed_now;
+
+                // TODO: エラーの内容をログに残せたら良さそう
+
+                // ロック解除
+                $email->is_locked = false;
+                $email->save();
+
+                // ...今度CRONが起動したらやり直す
+            }
+
+            // 現在実行中の runJob で、失敗回数が self::NUM_RETRY_PER_JOB 回を超えたら
+            // サーバー側の設定ミスなどが考えられるので、処理を中止する
+            if ($count_failed_now > self::NUM_RETRY_PER_JOB) {
+                // ...管理者にメールするなりログに書き込むなりする...
+
+                // とりあえず強制終了
+                break;
+            }
+
+            // 強制終了するか否か
+            if (now() - $start_time > self::SEC_PER_JOB) {
+                break;
+            }
+
+            // スリープ
+            sleep(self::SEND_INTERVAL_SEC);
+        }
+    }
+}

--- a/application/controllers/Home_staff.php
+++ b/application/controllers/Home_staff.php
@@ -626,7 +626,7 @@ class Home_staff extends MY_Controller
             'updated_by',
             'notes'
         );
-        
+
         if ($this->grocery_crud->getstate() !== 'edit' && $this->grocery_crud->getstate() !== 'add') {
             $this->grocery_crud->set_relation('created_by', 'users', '{student_id} {name_family} {name_given}');
             $this->grocery_crud->set_relation('updated_by', 'users', '{student_id} {name_family} {name_given}');

--- a/application/views/home_staff/home_staff.crud.html.twig
+++ b/application/views/home_staff/home_staff.crud.html.twig
@@ -15,6 +15,14 @@
 
   <h1 class="main__title">{{ page_title }}</h1>
 
+  {% if main_page_type == 'pages' %}
+    <p>
+      <a href="{{ base_url('/staff/send_emails') }}" class="btn btn-primary">
+        メールの一斉送信
+      </a>
+    </p>
+  {% endif %}
+
   {{ output | raw }}
 
 {% endblock %}

--- a/composer.lock
+++ b/composer.lock
@@ -1800,16 +1800,16 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v6.2.1",
+            "version": "v6.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a"
+                "reference": "149cfdf118b169f7840bbe3ef0d4bc795d1780c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a",
-                "reference": "5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/149cfdf118b169f7840bbe3ef0d4bc795d1780c9",
+                "reference": "149cfdf118b169f7840bbe3ef0d4bc795d1780c9",
                 "shasum": ""
             },
             "require": {
@@ -1858,7 +1858,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2019-04-21T09:21:45+00:00"
+            "time": "2019-11-12T09:31:26+00:00"
         },
         {
             "name": "symfony/console",

--- a/database/migrations/2019_12_16_134839_create_emails_table.php
+++ b/database/migrations/2019_12_16_134839_create_emails_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateEmailsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('emails', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('subject');
+            $table->longText('body');
+            $table->string('email_to');
+            $table->string('email_to_name');
+            $table->boolean('is_locked')->default(false);
+            $table->timestamp('sent_at')->nullable();
+            $table->integer('count_failed')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('emails');
+    }
+}

--- a/database/migrations/2019_12_16_134839_create_emails_table.php
+++ b/database/migrations/2019_12_16_134839_create_emails_table.php
@@ -19,7 +19,7 @@ class CreateEmailsTable extends Migration
             $table->longText('body');
             $table->string('email_to');
             $table->string('email_to_name');
-            $table->boolean('is_locked')->default(false);
+            $table->timestamp('locked_at')->nullable();
             $table->timestamp('sent_at')->nullable();
             $table->integer('count_failed')->default(0);
             $table->timestamps();

--- a/resources/views/emails/emails/send_email_service.blade.php
+++ b/resources/views/emails/emails/send_email_service.blade.php
@@ -1,0 +1,5 @@
+@component('mail::message')
+# {{ $subject }}
+
+{!! $body !!}
+@endcomponent

--- a/resources/views/staff/send_emails/list.blade.php
+++ b/resources/views/staff/send_emails/list.blade.php
@@ -1,0 +1,57 @@
+@extends('layouts.app')
+
+@section('title', (empty($circle) ? '団体情報新規作成' : '団体情報編集') . ' - ' . config('app.name') )
+
+@section('content')
+<div class="container">
+    @if (session('toast'))
+        <div class="alert alert-success" role="alert">
+            {{ session('toast') }}
+        </div>
+    @endif
+
+    <div class="card">
+        <div class="card-header">
+            配信するお知らせを選択
+        </div>
+        <div class="card-body">
+
+            <form method="post" action="{{ route('staff.send_emails') }}">
+                @csrf
+                @method('delete')
+                <button type="submit" class="btn btn-danger">
+                    メールの配信を全てキャンセル
+                </button>
+            </form>
+
+            <p class="text-muted">間違えてメールを配信してしまった場合、メールの配信を全てキャンセル(停止)できます。</p>
+
+            <hr>
+
+            @foreach ($pages as $page)
+                <details>
+                    <summary>
+                        {{ $page->title }}
+                    </summary>
+                    <pre class="card my-3 p-3">{{ $page->body }}</pre>
+                    <div class="mb-3">
+                        <form
+                            method="post"
+                            action="{{ route('staff.send_emails') }}"
+                            class="d-inline"
+                            onsubmit="return confirm('全ユーザーにメールが配信されますが、よろしいですか？')"
+                        >
+                            @csrf
+                            <input type="hidden" name="page_id" value="{{ $page->id }}">
+                            <button type="submit" class="btn btn-primary">
+                                全ユーザーに一斉送信する
+                            </button>
+                        </form>
+                    </div>
+                </details>
+                <hr>
+            @endforeach
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,6 +83,11 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
                 Route::post('/editor/api/delete_question', 'Staff\Forms\DeleteQuestionAction');
             });
 
+        // メール一斉送信
+        Route::get('/send_emails', 'Staff\SendEmails\ListAction')->name('send_emails');
+        Route::post('/send_emails', 'Staff\SendEmails\StoreAction');
+        Route::delete('/send_emails', 'Staff\SendEmails\DestroyAction');
+
         // 団体情報編集
         Route::get('/circles/{circle}/edit', 'Staff\Circles\EditAction')->name('circles.edit');
         Route::patch('/circles/{circle}', 'Staff\Circles\UpdateAction')->name('circles.update');


### PR DESCRIPTION
close #44

㊗️ PR 番号 100 ㊗️

## 懸念点
メール送信に失敗すると、Laravel が内部的に利用している SwiftMailer ライブラリが Notice Error を発してしまう。fwrite 関数。

Notice Error は try-catch 文で捕捉できないため、メール送信の失敗を検知できず、ロックを解除することもできない。

つまり、メール送信に１回失敗すると、そのメールアドレスに二度と送信されなくなってしまう。