### PR TITLE
【申請】回答確認メールは団体所属者全員に送信する #112

### DIFF
--- a/application/controllers/home/Applications_form.php
+++ b/application/controllers/home/Applications_form.php
@@ -370,7 +370,7 @@ class Applications_form extends Home_base_controller
 
             // 完了メールを送信
             $vars_email = [];
-            $vars_email["name_to"] = $this->_get_login_user()->name_family . " " .
+            $vars_email["submitted_by"] = $this->_get_login_user()->name_family . " " .
                 $this->_get_login_user()->name_given;
             $vars_email["form_name"] = $vars["form"]->name;
             $vars_email["type"] = $type === "create" ? "新規作成" : "更新";
@@ -382,16 +382,20 @@ class Applications_form extends Home_base_controller
             $vars_email["datetime"] = date("Y/m/d H:i:s");
             $vars_email["answers"] = $answers_for_email;
 
-            // 回答者に送信するメール
-            $this->_send_email(
-                $this->_get_login_user()->email,
-                "申請「" . $vars_email["form_name"] . "」を承りました",
-                "email/applications_form_sent",
-                $vars_email
-            );
+            foreach ($this->circles->get_user_info_by_circle_id($circleId) as $user) {
+                // 回答者に送信するメール
+                $vars_email["name_to"] = $user->name_family . " " . $user->name_given;
+                $this->_send_email(
+                    $user->email,
+                    "申請「" . $vars_email["form_name"] . "」を承りました",
+                    "email/applications_form_sent",
+                    $vars_email
+                );
+            }
 
             // フォーム管理者に送信するメール
             $manager = $this->users->get_user_by_user_id($vars["form"]->created_by);
+            $vars_email["name_to"] = $manager->name_family . " " . $manager->name_given;
             $this->_send_email(
                 $manager->email,
                 "[スタッフ用控え]申請「" . $vars_email["form_name"] . "」を承りました",

--- a/application/views/email/applications_form_sent.txt.twig
+++ b/application/views/email/applications_form_sent.txt.twig
@@ -17,6 +17,7 @@
 
 申請名 : {{ form_name | raw }}
 団体名 : {{ circle.name | raw }}
+申請者 : {{ submitted_by | raw }}
 {% if booth %}
 ブース : {% spaceless %}
   {% if booth.name is empty %}


### PR DESCRIPTION
close #112

## 実装内容
- 申請を提出したら、その団体に所属しているユーザー全員に対し確認メールを送信するようにした

## 懸念点・レビュワーに見て欲しい内容
- 確認メールが確実に団体所属者全員に到着するか
- 他人の名前、メールアドレスが意図せず他の人にバレるようなことがないか
    - （メール本文中の「申請者」は、申請した人の名前を掲載するので、他人にバレてしまうが、そういう仕様）