### PR TITLE
【v2】タブ・iPhone X 対応 #172

### DIFF
--- a/resources/sass/v2/_variables.scss
+++ b/resources/sass/v2/_variables.scss
@@ -34,17 +34,21 @@ $content-width: calc(100vw - #{$drawer-width});
 $transition-base: 0.3s ease;
 $transition-base-fast: 0.2s ease;
 $border-radius: 0.25rem;
+$bottom-tabs-height: 4.5rem;
 
 // Container Width
 $container-width-wide: 1200px;
 $container-width: 1024px;
+$container-width-medium: 600px;
 $container-width-narrow: 400px;
 
 // Media Breakpoints
 $breakpoint-drawer-hide: 1240px;
 $breakpoint-listview-single-col: 860px;
+$breakpoint-bottom-tabs: $breakpoint-drawer-hide;
 
 // Z indexes
 $z-index-drawer: 9990;
 $z-index-drawer-backdrop: 9989;
 $z-index-navbar: 9980;
+$z-index-bottom_tabs: 9980;

--- a/resources/sass/v2/app.scss
+++ b/resources/sass/v2/app.scss
@@ -1,6 +1,11 @@
 @import 'normalize';
 @import 'variables';
 
+// Utils
+@import 'utils/text';
+@import 'utils/spacing';
+@import 'utils/link';
+
 // Layout
 @import 'layout/base';
 @import 'layout/main_wrapper';
@@ -19,7 +24,4 @@
 @import 'modules/markdown';
 @import 'modules/day_calendar';
 @import 'modules/tab_strip';
-
-// Utils
-@import 'utils/text';
-@import 'utils/spacing';
+@import 'modules/bottom_tabs';

--- a/resources/sass/v2/modules/_bottom_tabs.scss
+++ b/resources/sass/v2/modules/_bottom_tabs.scss
@@ -1,0 +1,58 @@
+body {
+  padding-bottom: calc(env(safe-area-inset-bottom) + #{$bottom-tabs-height});
+  @media screen and (min-width: $breakpoint-bottom-tabs) {
+    padding-bottom: 0;
+  }
+}
+
+.bottom_tabs {
+  background: #fff;
+  bottom: 0;
+  box-shadow: 0 -1px 4px rgba($color-text, 0.05);
+  height: calc(env(safe-area-inset-bottom) + #{$bottom-tabs-height});
+  left: 0;
+  position: fixed;
+  width: 100vw;
+  z-index: $z-index-bottom-tabs;
+  &-container {
+    align-items: center;
+    display: flex;
+    height: 100%;
+    padding: 0 $spacing env(safe-area-inset-bottom);
+  }
+  &-tab {
+    $selector-tab: &;
+    @include link-style-reset($color-muted);
+
+    align-items: center;
+    color: $color-muted;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    width: 100%;
+    &__icon {
+      font-size: 1.4rem;
+      margin-bottom: $spacing-sm;
+    }
+    &__label {
+      border-radius: 9999px;
+      display: inline-block;
+      font-size: 0.6rem;
+      font-weight: bold;
+      padding: 0 $spacing-sm;
+    }
+    &.is-active {
+      @include link-style-reset($color-primary);
+
+      color: $color-primary;
+      #{$selector-tab}__label {
+        background: $color-bg-light;
+        color: $color-primary;
+      }
+    }
+  }
+
+  @media screen and (min-width: $breakpoint-bottom-tabs) {
+    display: none;
+  }
+}

--- a/resources/sass/v2/modules/_container.scss
+++ b/resources/sass/v2/modules/_container.scss
@@ -9,6 +9,9 @@
   &.is-wide {
     max-width: $container-width-wide;
   }
+  &.is-medium {
+    max-width: $container-width-medium;
+  }
   &.is-narrow {
     max-width: $container-width-narrow;
   }

--- a/resources/sass/v2/utils/_link.scss
+++ b/resources/sass/v2/utils/_link.scss
@@ -1,0 +1,8 @@
+@mixin link-style-reset($color: $color-text) {
+  &:hover,
+  &:focus,
+  &:active {
+    color: $color;
+    text-decoration: none;
+  }
+}

--- a/resources/views/v2/contacts/form.blade.php
+++ b/resources/views/v2/contacts/form.blade.php
@@ -71,3 +71,7 @@
     </form>
 </main>
 @endsection
+
+@section('bottom_tabs')
+{{-- TODO: 完全にLaravel化したら、このセクションは完全削除する --}}
+@endsection

--- a/resources/views/v2/layouts/app.blade.php
+++ b/resources/views/v2/layouts/app.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>
         @hasSection ('title')
             @yield('title') —

--- a/resources/views/v2/layouts/app.blade.php
+++ b/resources/views/v2/layouts/app.blade.php
@@ -77,6 +77,33 @@
         @endif
         @yield('content')
     </div>
+    @section('bottom_tabs')
+    <div class="bottom_tabs">
+        <div class="container is-medium bottom_tabs-container">
+            {{-- TODO: Request::is の引数は将来的に '' (空文字) にしたい --}}
+            <a href="{{ url('/') }}" class="bottom_tabs-tab{{ Request::is('login') || Request::is('home*') ? ' is-active' : '' }}">
+                <i class="fas fa-home bottom_tabs-tab__icon"></i>
+                <div class="bottom_tabs-tab__label">ホーム</div>
+            </a>
+            <a href="{{ route('pages.index') }}" class="bottom_tabs-tab{{ Request::is('pages*') ? ' is-active' : '' }}">
+                <i class="fas fa-bullhorn bottom_tabs-tab__icon"></i>
+                <div class="bottom_tabs-tab__label">お知らせ</div>
+            </a>
+            <a href="{{ route('documents.index') }}" class="bottom_tabs-tab{{ Request::is('documents*') ? ' is-active' : '' }}">
+                <i class="far fa-file-alt bottom_tabs-tab__icon"></i>
+                <div class="bottom_tabs-tab__label">配布資料</div>
+            </a>
+            <a href="{{ url('home/applications') }}" class="bottom_tabs-tab">
+                <i class="far fa-edit bottom_tabs-tab__icon"></i>
+                <div class="bottom_tabs-tab__label">申請</div>
+            </a>
+            <a href="{{ route('contacts') }}" class="bottom_tabs-tab{{ Request::is('contacts*') ? ' is-active' : '' }}">
+                <i class="far fa-envelope bottom_tabs-tab__icon"></i>
+                <div class="bottom_tabs-tab__label">お問い合わせ</div>
+            </a>
+        </div>
+    </div>
+    @show
 </div>
 
 </body>


### PR DESCRIPTION
## 実装内容
close #172 
<!-- どんな実装をしたのか -->

- iPhone X 対応を CSS で真面目にやろうとすると手間なので、CSS での iPhone X 対応はなし
- スマホの場合、下タブを表示し、サイドドロワーを開くことなく画面遷移を可能に

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
