### PR TITLE
【新デザイン(v2)のtextarea】行間を少し広くして読みやすくする #165

### DIFF
--- a/resources/sass/v2/modules/_forms.scss
+++ b/resources/sass/v2/modules/_forms.scss
@@ -19,7 +19,8 @@ textarea {
     border-radius: $border-radius;
     box-shadow: inset 0 0.5px 1.5px rgba($color-text, 0.1);
     font-size: $font-size-input;
-    padding: 0.75rem $spacing-md;
+    line-height: 1.6;
+    padding: $spacing-sm $spacing-md;
     transition: #{$transition-base-fast} background-color, #{$transition-base-fast} box-shadow;
     width: 100%;
     @at-root {


### PR DESCRIPTION
## 実装内容
close #165 
<!-- どんな実装をしたのか -->
- `line-height` を `1.6` に設定
- `padding` の上下を `$spacing-sm` に変更

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
