### PR TITLE
CI&Laravel】各フレームワークへの振り分け方式を正規表現ベースにする #183

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -47,25 +47,25 @@
     // Laravel にルーティングされる
     $LARAVEL_PATHS = [
         // Home
-        '^\/home__v2',
-        '^\/pages',
-        '^\/documents',
-        '^\/schedules',
+        '/^\/home__v2/',
+        '/^\/pages/',
+        '/^\/documents/',
+        '/^\/schedules/',
         // Auth
-        '^\/login',
-        '^\/logout',
-        '^\/register',
-        '^\/password',
-        '^\/email',
+        '/^\/login/',
+        '/^\/logout/',
+        '/^\/register/',
+        '/^\/password/',
+        '/^\/email/',
         // Users
-        '^\/change_password',
-        '^\/user',
-        '^\/contacts',
-        '^\/selector',
+        '/^\/change_password/',
+        '/^\/user/',
+        '/^\/contacts/',
+        '/^\/selector/',
         // Staff
-        '^\/staff',
+        '/^\/staff/',
         // Debugbar
-        '^\/_debugbar',
+        '/^\/_debugbar/',
     ];
 
     if (file_exists($down_path = __DIR__. '/../storage/framework/down')) {
@@ -81,7 +81,7 @@
     $request_uri = $_SERVER['REQUEST_URI'];
 
     foreach ($LARAVEL_PATHS as $path) {
-        if (preg_match('/' . $path . '/', $request_uri)) {
+        if (preg_match($path , $request_uri)) {
             require __DIR__. '/index_laravel.php';
             exit;
         }

--- a/public/index.php
+++ b/public/index.php
@@ -47,25 +47,25 @@
     // Laravel にルーティングされる
     $LARAVEL_PATHS = [
         // Home
-        '/home__v2',
-        '/pages',
-        '/documents',
-        '/schedules',
+        '^\/home__v2',
+        '^\/pages',
+        '^\/documents',
+        '^\/schedules',
         // Auth
-        '/login',
-        '/logout',
-        '/register',
-        '/password',
-        '/email',
+        '^\/login',
+        '^\/logout',
+        '^\/register',
+        '^\/password',
+        '^\/email',
         // Users
-        '/change_password',
-        '/user',
-        '/contacts',
-        '/selector',
+        '^\/change_password',
+        '^\/user',
+        '^\/contacts',
+        '^\/selector',
         // Staff
-        '/staff',
+        '^\/staff',
         // Debugbar
-        '/_debugbar',
+        '^\/_debugbar',
     ];
 
     if (file_exists($down_path = __DIR__. '/../storage/framework/down')) {
@@ -81,8 +81,7 @@
     $request_uri = $_SERVER['REQUEST_URI'];
 
     foreach ($LARAVEL_PATHS as $path) {
-        $path = str_replace('/', '\/', preg_quote($path));
-        if (preg_match('/^'. $path. '/', $request_uri)) {
+        if (preg_match('/' . $path . '/', $request_uri)) {
             require __DIR__. '/index_laravel.php';
             exit;
         }


### PR DESCRIPTION
## 実装内容
close #183 
<!-- どんな実装をしたのか -->
- index.php の `LARAVEL_PATH` の配列を正規表現で入力するように変更
- 後方一致 `$` も使うことがあると思うので 前方一致 `^` も記述するようにしました

## 懸念点

## レビュワーに見て欲しい点
- すべてのURLで正常に振り分けされるか

## 参考URL
