### PR TITLE
【ホーム(v2) & スケジュール(v2)】スケジュールの説明が空欄の場合にエラーが出力される #198

### DIFF
--- a/app/Services/Utils/FormatTextService.php
+++ b/app/Services/Utils/FormatTextService.php
@@ -23,9 +23,10 @@ class FormatTextService
      *
      * ※ 確実に「...」を表示するため、 mb_strimwidth の機能ではなく単に「...」を文字列連結している
      */
-    public static function summary(string $text): string
+    public static function summary(?string $text): string
     {
-        return mb_strimwidth(strip_tags(ParseMarkdownService::render(mb_strimwidth($text, 0, 200))), 0, 100) . '...';
+        return empty($text) ? ''
+            : mb_strimwidth(strip_tags(ParseMarkdownService::render(mb_strimwidth($text, 0, 200))), 0, 100) . '...';
     }
 
     /**

--- a/app/Services/Utils/ParseMarkdownService.php
+++ b/app/Services/Utils/ParseMarkdownService.php
@@ -9,8 +9,11 @@ use cebe\markdown\GithubMarkdown as Parser;
 
 class ParseMarkdownService
 {
-    public static function render(string $markdown): string
+    public static function render(?string $markdown): string
     {
+        if (empty($markdown)) {
+            return '';
+        }
         $parser = App::make(Parser::class);
         $parser->enableNewlines = true;
         return $parser->parse($markdown);


### PR DESCRIPTION
## 実装内容
close #198 
<!-- どんな実装をしたのか -->
- null も受け取れるようにし、null だった場合に `''` を返すように変更
- ホームでも同じバグがあったので修正しました

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
