### PR TITLE
メール認証未完了時のアラートを実装（＋参加登録アラートを改良） #179

### DIFF
--- a/app/Providers/BladeServiceProvider.php
+++ b/app/Providers/BladeServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Auth;
 
 class BladeServiceProvider extends ServiceProvider
 {

--- a/resources/sass/v2/modules/_btn.scss
+++ b/resources/sass/v2/modules/_btn.scss
@@ -39,7 +39,7 @@
     @include btn(#fff, $color-primary, lighten($color-primary, 5%), $color-primary, $color-primary);
   }
   &.is-secondary {
-    @include btn($color-text, #fff, lighten($color-border, 15%), $color-border);
+    @include btn($color-text, #fff, $color-bg-grey, $color-border);
   }
   &.is-danger {
     @include btn(#fff, $color-danger, lighten($color-danger, 5%), $color-danger, $color-danger);

--- a/resources/sass/v2/modules/_btn.scss
+++ b/resources/sass/v2/modules/_btn.scss
@@ -51,4 +51,8 @@
   &.is-no-border {
     border: none;
   }
+  &.is-wide {
+    padding-left: $spacing-lg;
+    padding-right: $spacing-lg;
+  }
 }

--- a/resources/sass/v2/modules/_top_alert.scss
+++ b/resources/sass/v2/modules/_top_alert.scss
@@ -16,10 +16,10 @@
   &__title {
     font-size: 1rem;
     font-weight: bold;
-    margin: 0 0 $spacing-xs;
+    margin: 0;
   }
   &__body {
     font-size: 1rem;
-    margin: 0;
+    margin: $spacing-sm 0 0;
   }
 }

--- a/resources/sass/v2/utils/_spacing.scss
+++ b/resources/sass/v2/utils/_spacing.scss
@@ -6,6 +6,9 @@
   &-md {
     padding-top: $spacing-md !important;
   }
+  &-sm {
+    padding-top: $spacing-sm !important;
+  }
 }
 
 .pb-spacing {

--- a/resources/views/v2/home.blade.php
+++ b/resources/views/v2/home.blade.php
@@ -3,14 +3,19 @@
 @section('content')
 
 @auth
-@if (count($my_circles) < 1)
+@if (Auth::user()->areBothEmailsVerified() && count($my_circles) < 1)
 <div class="top_alert is-primary">
     <h2 class="top_alert__title">
         <i class="fa fa-exclamation-triangle fa-fw" aria-hidden="true"></i>
-        団体参加登録が未完了
+        参加登録をしましょう！
     </h2>
     <p class="top_alert__body">
-        団体参加登録がお済みでない場合、申請機能など、{{ config('app.name') }} の一部機能がご利用になれません
+        まだ参加登録がお済みでないようですね。まずは参加登録からはじめましょう！
+    </p>
+    <p class="top_alert__body pt-spacing-sm">
+        <a href="#" class="btn is-secondary is-no-border is-wide">
+            <strong>参加登録をはじめる</strong>
+        </a>
     </p>
 </div>
 @endif

--- a/resources/views/v2/home.blade.php
+++ b/resources/views/v2/home.blade.php
@@ -6,7 +6,7 @@
 @if (Auth::user()->areBothEmailsVerified() && count($my_circles) < 1)
 <div class="top_alert is-primary">
     <h2 class="top_alert__title">
-        <i class="fa fa-exclamation-triangle fa-fw" aria-hidden="true"></i>
+        <i class="fa fa-info-circle fa-fw" aria-hidden="true"></i>
         参加登録をしましょう！
     </h2>
     <p class="top_alert__body">

--- a/resources/views/v2/layouts/app.blade.php
+++ b/resources/views/v2/layouts/app.blade.php
@@ -67,6 +67,36 @@
         </div>
     </div>
     <div class="content">
+        @auth
+            @unless (Auth::user()->areBothEmailsVerified())
+                <div class="top_alert is-primary">
+                    <h2 class="top_alert__title">
+                        <i class="fa fa-exclamation-triangle fa-fw" aria-hidden="true"></i>
+                        メール認証を行ってください
+                    </h2>
+                    <p class="top_alert__body">
+                        {{ config('app.name') }}の全機能を利用するには、次のメールアドレス宛に送信された確認メール内のURLにアクセスしてください。
+                        <strong>
+                        @unless (Auth::user()->hasVerifiedUnivemail())
+                            {{ Auth::user()->univemail }}
+                            @unless (Auth::user()->hasVerifiedEmail())
+                                •
+                            @endunless
+                        @endunless
+                        @unless (Auth::user()->hasVerifiedEmail())
+                            {{ Auth::user()->email }}
+                        @endunless
+                        </strong>
+                    </p>
+                    <form class="top_alert__body pt-spacing-sm" action="{{ route('verification.resend') }}" method="post">
+                        @csrf
+                        <button class="btn is-secondary is-no-border is-wide">
+                            <strong>確認メールを再送</strong>
+                        </button>
+                    </form>
+                </div>
+            @endunless
+        @endauth
         @if (Session::has('topAlert.title'))
             <div class="top_alert is-primary">
                 <h2 class="top_alert__title">{{ session('topAlert.title') }}</h2>


### PR DESCRIPTION
## 実装内容
close #179
<!-- どんな実装をしたのか -->

メール認証が完了していない場合、全ページに、その旨のアラートを表示するようにしました。

![image](https://user-images.githubusercontent.com/6687653/73594399-930d2080-4551-11ea-925c-50a552b505ae.png)

ついでに、参加登録が未完了の際のアラートを改良しました。トップページのみ表示されます。
（ボタンのリンク先は未実装だが、まだv2は公開していないので、問題ないかと。）

![image](https://user-images.githubusercontent.com/6687653/73594409-a4eec380-4551-11ea-8964-098c0e8d61ae.png)


## 懸念点

## レビュワーに見て欲しい点

## 参考URL
