### PR TITLE
【申請フォームエディター】「複数選択」「単一選択」で、選択肢未設定時の表示を変更 #191

### DIFF
--- a/resources/js/forms_editor/components/form/QuestionCheckbox.vue
+++ b/resources/js/forms_editor/components/form/QuestionCheckbox.vue
@@ -18,11 +18,13 @@
           </div>
         </template>
         <template v-else>
-          <p class="empty-option">
-            <i class="fa fa-exclamation-triangle mr-1"></i>
-            <b>選択肢がありません。</b>
-          </p>
-          <p class="empty-option">選択肢を1つ以上入力してください。</p>
+          <div class="empty-option">
+            <p class="empty-option-text">
+              <i class="fa fa-exclamation-triangle mr-1"></i>
+              <b>選択肢がありません。</b>
+            </p>
+            <p class="empty-option-text">選択肢を1つ以上入力してください。</p>
+          </div>
         </template>
       </div>
     </template>

--- a/resources/js/forms_editor/components/form/QuestionCheckbox.vue
+++ b/resources/js/forms_editor/components/form/QuestionCheckbox.vue
@@ -18,11 +18,11 @@
           </div>
         </template>
         <template v-else>
-          <p>
-            <i class="fa fa-exclamation-triangle mr-1"></i
-            ><b>選択肢がありません。</b>
+          <p class="empty-option">
+            <i class="fa fa-exclamation-triangle mr-1"></i>
+            <b>選択肢がありません。</b>
           </p>
-          <p>選択肢を1つ以上入力してください。</p>
+          <p class="empty-option">選択肢を1つ以上入力してください。</p>
         </template>
       </div>
     </template>

--- a/resources/js/forms_editor/components/form/QuestionCheckbox.vue
+++ b/resources/js/forms_editor/components/form/QuestionCheckbox.vue
@@ -9,12 +9,21 @@
         <p class="form-text text-muted mb-2">
           {{ description }}
         </p>
-        <div class="form-check mb-1" v-for="option in options" :key="option">
-          <input class="form-check-input" type="checkbox" tabindex="-1" />
-          <p class="form-check-label">
-            {{ option }}
+        <template v-if="options">
+          <div class="form-check mb-1" v-for="option in options" :key="option">
+            <input class="form-check-input" type="checkbox" tabindex="-1" />
+            <p class="form-check-label">
+              {{ option }}
+            </p>
+          </div>
+        </template>
+        <template v-else>
+          <p>
+            <i class="fa fa-exclamation-triangle mr-1"></i
+            ><b>選択肢がありません。</b>
           </p>
-        </div>
+          <p>選択肢を1つ以上入力してください。</p>
+        </template>
       </div>
     </template>
     <template v-slot:edit-panel>
@@ -59,7 +68,7 @@ export default {
     options() {
       return this.question.options
         ? this.question.options.trim().split(/\r\n|\n/)
-        : ['(選択肢なし)']
+        : null
     },
     is_required() {
       return this.question.is_required

--- a/resources/js/forms_editor/components/form/QuestionRadio.vue
+++ b/resources/js/forms_editor/components/form/QuestionRadio.vue
@@ -18,11 +18,13 @@
           </div>
         </template>
         <template v-else>
-          <p class="empty-option">
-            <i class="fa fa-exclamation-triangle mr-1"></i>
-            <b>選択肢がありません。</b>
-          </p>
-          <p class="empty-option">選択肢を1つ以上入力してください。</p>
+          <div class="empty-option">
+            <p class="empty-option-text">
+              <i class="fa fa-exclamation-triangle mr-1"></i>
+              <b>選択肢がありません。</b>
+            </p>
+            <p class="empty-option-text">選択肢を1つ以上入力してください。</p>
+          </div>
         </template>
       </div>
     </template>

--- a/resources/js/forms_editor/components/form/QuestionRadio.vue
+++ b/resources/js/forms_editor/components/form/QuestionRadio.vue
@@ -18,11 +18,11 @@
           </div>
         </template>
         <template v-else>
-          <p>
-            <i class="fa fa-exclamation-triangle mr-1"></i
-            ><b>選択肢がありません。</b>
+          <p class="empty-option">
+            <i class="fa fa-exclamation-triangle mr-1"></i>
+            <b>選択肢がありません。</b>
           </p>
-          <p>選択肢を1つ以上入力してください。</p>
+          <p class="empty-option">選択肢を1つ以上入力してください。</p>
         </template>
       </div>
     </template>

--- a/resources/js/forms_editor/components/form/QuestionRadio.vue
+++ b/resources/js/forms_editor/components/form/QuestionRadio.vue
@@ -9,12 +9,21 @@
         <p class="form-text text-muted mb-2">
           {{ description }}
         </p>
-        <div class="form-check mb-1" v-for="option in options" :key="option">
-          <input class="form-check-input" type="checkbox" tabindex="-1" />
-          <p class="form-check-label">
-            {{ option }}
+        <template v-if="options">
+          <div class="form-check mb-1" v-for="option in options" :key="option">
+            <input class="form-check-input" type="checkbox" tabindex="-1" />
+            <p class="form-check-label">
+              {{ option }}
+            </p>
+          </div>
+        </template>
+        <template v-else>
+          <p>
+            <i class="fa fa-exclamation-triangle mr-1"></i
+            ><b>選択肢がありません。</b>
           </p>
-        </div>
+          <p>選択肢を1つ以上入力してください。</p>
+        </template>
       </div>
     </template>
     <template v-slot:edit-panel>
@@ -59,7 +68,7 @@ export default {
     options() {
       return this.question.options
         ? this.question.options.trim().split(/\r\n|\n/)
-        : ['(選択肢なし)']
+        : null
     },
     is_required() {
       return this.question.is_required

--- a/resources/js/forms_editor/components/form/QuestionSelect.vue
+++ b/resources/js/forms_editor/components/form/QuestionSelect.vue
@@ -24,11 +24,11 @@
           </ul>
         </template>
         <template v-else>
-          <p>
-            <i class="fa fa-exclamation-triangle mr-1"></i
-            ><b>選択肢がありません。</b>
+          <p class="empty-option">
+            <i class="fa fa-exclamation-triangle mr-1"></i>
+            <b>選択肢がありません。</b>
           </p>
-          <p>選択肢を1つ以上入力してください。</p>
+          <p class="empty-option">選択肢を1つ以上入力してください。</p>
         </template>
       </div>
     </template>

--- a/resources/js/forms_editor/components/form/QuestionSelect.vue
+++ b/resources/js/forms_editor/components/form/QuestionSelect.vue
@@ -9,18 +9,27 @@
         <p class="form-text text-muted mb-2">
           {{ description }}
         </p>
-        <select class="custom-select" tabindex="-1">
-          <option>単一選択(ドロップダウン)</option>
-        </select>
-        <ul class="list-group">
-          <li
-            class="list-group-item py-1"
-            v-for="option in options"
-            :key="option"
-          >
-            {{ option }}
-          </li>
-        </ul>
+        <template v-if="options">
+          <select class="custom-select" tabindex="-1">
+            <option>単一選択(ドロップダウン)</option>
+          </select>
+          <ul class="list-group">
+            <li
+              class="list-group-item py-1"
+              v-for="option in options"
+              :key="option"
+            >
+              {{ option }}
+            </li>
+          </ul>
+        </template>
+        <template v-else>
+          <p>
+            <i class="fa fa-exclamation-triangle mr-1"></i
+            ><b>選択肢がありません。</b>
+          </p>
+          <p>選択肢を1つ以上入力してください。</p>
+        </template>
       </div>
     </template>
     <template v-slot:edit-panel>
@@ -65,7 +74,7 @@ export default {
     options() {
       return this.question.options
         ? this.question.options.trim().split(/\r\n|\n/)
-        : ['(選択肢なし)']
+        : null
     },
     is_required() {
       return this.question.is_required

--- a/resources/js/forms_editor/components/form/QuestionSelect.vue
+++ b/resources/js/forms_editor/components/form/QuestionSelect.vue
@@ -24,11 +24,13 @@
           </ul>
         </template>
         <template v-else>
-          <p class="empty-option">
-            <i class="fa fa-exclamation-triangle mr-1"></i>
-            <b>選択肢がありません。</b>
-          </p>
-          <p class="empty-option">選択肢を1つ以上入力してください。</p>
+          <div class="empty-option">
+            <p class="empty-option-text">
+              <i class="fa fa-exclamation-triangle mr-1"></i>
+              <b>選択肢がありません。</b>
+            </p>
+            <p class="empty-option-text">選択肢を1つ以上入力してください。</p>
+          </div>
         </template>
       </div>
     </template>

--- a/resources/sass/forms_editor.scss
+++ b/resources/sass/forms_editor.scss
@@ -48,6 +48,10 @@ body {
 
 
 .empty-option {
+  padding-top: 0.25rem;
+}
+
+.empty-option-text {
   margin-bottom: 0;
   margin-top: 0.25rem;
 }

--- a/resources/sass/forms_editor.scss
+++ b/resources/sass/forms_editor.scss
@@ -45,3 +45,9 @@ body {
   width: $editor-sidebar-width;
   z-index: 10;
 }
+
+
+.empty-option {
+  margin-bottom: 0;
+  margin-top: 0.25rem;
+}


### PR DESCRIPTION
## 実装内容
close #191 
<!-- どんな実装をしたのか -->
- 「複数選択」「単一選択」の選択肢がないときに、画像のように表示
![image](https://user-images.githubusercontent.com/8391342/75018564-85a0e180-54d2-11ea-9da3-543caa8dfab3.png)

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
