### PR TITLE
【Staff/申請】アップロードされたファイルがないフォームでZIPダウンロードしようとするとエラーになる #261

### DIFF
--- a/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
@@ -43,8 +43,9 @@ class DownloadZipAction extends Controller
         $zip_path = storage_path("app/answer_details_zip/{$zip_filename}");
 
         if ($zip->open($zip_path, ZipArchive::CREATE) !== true) {
-            abort(500, 'このサーバーは、ZIPダウンロードに対応していません');
-            return;
+            return back()
+                ->with('topAlert.type', 'danger')
+                ->with('topAlert.title', 'このサーバーは、ZIPダウンロードに対応していません');
         }
 
         $tuples = array_map(function ($path) {
@@ -65,6 +66,11 @@ class DownloadZipAction extends Controller
             return null;
         }, $uploaded_file_paths);
         $tuples = array_filter($tuples);
+
+        if (!is_array($tuples) || count($tuples) === 0) {
+            return back()
+                ->with('topAlert.title', 'ダウンロードできるファイルはありません');
+        }
 
         foreach ($tuples as $tuple) {
             [$fullpath, $localname] = $tuple;

--- a/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
@@ -47,7 +47,7 @@ class DownloadZipAction extends Controller
             return;
         }
 
-        $fullpaths = array_map(function ($path) {
+        $tuples = array_map(function ($path) {
             if (strpos($path, 'answer_details/') === 0 && file_exists($fullpath = Storage::path($path))) {
                 // Project v2 申請フォームからアップロードされたファイル
                 //
@@ -64,10 +64,10 @@ class DownloadZipAction extends Controller
             }
             return null;
         }, $uploaded_file_paths);
-        $fullpaths = array_filter($fullpaths);
+        $tuples = array_filter($tuples);
 
-        foreach ($fullpaths as $path) {
-            [$fullpath, $localname] = $path;
+        foreach ($tuples as $tuple) {
+            [$fullpath, $localname] = $tuple;
             $zip->addFile($fullpath, $localname);
         }
 

--- a/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
@@ -38,16 +38,6 @@ class DownloadZipAction extends Controller
             Storage::makeDirectory('answer_details_zip');
         }
 
-        $zip = new ZipArchive();
-        $zip_filename = 'uploads_' . $form_id . '_' . date('Y-m-d_H-i-s') . '.zip';
-        $zip_path = storage_path("app/answer_details_zip/{$zip_filename}");
-
-        if ($zip->open($zip_path, ZipArchive::CREATE) !== true) {
-            return back()
-                ->with('topAlert.type', 'danger')
-                ->with('topAlert.title', 'このサーバーは、ZIPダウンロードに対応していません');
-        }
-
         $tuples = array_map(function ($path) {
             if (
                 strpos($path, 'answer_details/') === 0 &&
@@ -75,6 +65,16 @@ class DownloadZipAction extends Controller
         if (!is_array($tuples) || count($tuples) === 0) {
             return back()
                 ->with('topAlert.title', 'ダウンロードできるファイルはありません');
+        }
+
+        $zip = new ZipArchive();
+        $zip_filename = 'uploads_' . $form_id . '_' . date('Y-m-d_H-i-s') . '.zip';
+        $zip_path = storage_path("app/answer_details_zip/{$zip_filename}");
+
+        if ($zip->open($zip_path, ZipArchive::CREATE) !== true) {
+            return back()
+                ->with('topAlert.type', 'danger')
+                ->with('topAlert.title', 'このサーバーは、ZIPダウンロードに対応していません');
         }
 
         foreach ($tuples as $tuple) {

--- a/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
@@ -49,14 +49,19 @@ class DownloadZipAction extends Controller
         }
 
         $tuples = array_map(function ($path) {
-            if (strpos($path, 'answer_details/') === 0 && file_exists($fullpath = Storage::path($path))) {
+            if (
+                strpos($path, 'answer_details/') === 0 &&
+                file_exists($fullpath = Storage::path($path)) &&
+                is_file($fullpath)
+            ) {
                 // Project v2 申請フォームからアップロードされたファイル
                 //
                 // TODO: 将来的に、ダウンロードされるファイル名に answer_details__ は含めないようにしたい
                 // TODO: 別件だが、回答一覧画面でも answer_details/ というパスは表示しないようにしたい
                 return [$fullpath, str_replace('answer_details/', 'answer_details__', $path)];
             } elseif (
-                file_exists($fullpath = config('portal.codeigniter_upload_dir') . '/form_file/' . basename($path))
+                file_exists($fullpath = config('portal.codeigniter_upload_dir') . '/form_file/' . basename($path)) &&
+                is_file($fullpath)
             ) {
                 // CodeIgniter 申請フォームからアップロードされたファイル
                 //


### PR DESCRIPTION
## 実装内容
close #261
<!-- どんな実装をしたのか -->

- 変数名などにおいてリファクタリング
- サーバーが ZipArchive 非対応の場合、topAlert でエラー表示
- アップロードされたファイルがないフォームでZIPダウンロードしようとした場合、topAlert でエラー表示

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
